### PR TITLE
Add lots of `iterable` methods

### DIFF
--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -74,7 +74,7 @@ export function* filter<T>(iterable: Iterable<T>, predicate: (value: T, index: n
 }
 
 /**
- * Converts an iterable to a single value by using an accumulator function
+ * Converts an iterable to a single value by using an accumulator function.
  * @param accumulator A function that is called on each element in the iterable along with the previous result of the function.
  * It may optionally take the current index of the element.
  * @param initialValue If specified, used as the initial value for `accumulated`.
@@ -105,6 +105,11 @@ export function reduce<T>(iterable: Iterable<T>, accumulator: (accumulated: T, c
         return accumulated;
     }
 }
+
+// NOTE: `Array.prototype.reduce` should actually be sufficient for most cases,
+// and `reduce` needs to iterate over the whole iterable anyway.
+// So, I'm not going to bother to implement the special cases of `reduce` (`some`, `every`, etc.).
+// The iterable version of `reduce` may be useful to avoid loading the entire collection into memory at once.
 
 /** Returns the first `n` elements of an iterable. */
 export function* take<T>(n: number, iterable: Iterable<T>): Generator<T, void> {

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -1,7 +1,6 @@
 /**
  * Check whether an object implements the iterable protocol.
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
- * Adapted from https://stackoverflow.com/a/32538867/3084634.
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
  */
 export function isIterable(obj: any): boolean {
     return obj !== undefined
@@ -27,17 +26,23 @@ export function* sequence<T>(n: number, sequencer: (i: number) => T) {
 }
 
 /**
- * Generate a sequence of integers for the half-open set `[min, max)`.
- * If `min` is not an integer, it is rounded up.
- * If `max` is not an integer, it is rounded down.
- * If `min` >= `max` (after rounding), an empty array is returned.
+ * Generate a sequence of integers for the half-open set `[min, max)` by increments of `step`.
+ * @param {number} min - Lower bound (inclusive) of the range.
+ * @param {number} max - Upper bound (exclusive) of the range.
+ * @param {number} step - Must be positive. Default = 1.
+ * @returns If `min` >= `max` (after rounding), an empty array is returned.
  */
-export function range(min: number, max: number): Generator<number, void> {
-    min = Math.ceil(min);
-    max = Math.floor(max);
+export function* range(min: number, max: number, step?: number): Generator<number, void> {
+    step = step ?? 1;
+    if (step <= 0) {
+        throw new RangeError('Invalid step size');
+    }
 
-    const sizeOfRange = Math.max(0, max - min);
-    return sequence(sizeOfRange, n => n + min);
+    let value = min;
+    while (value < max) {
+        yield value;
+        value += step;
+    }
 }
 
 /**

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -32,7 +32,7 @@ export function* sequence<T>(n: number, sequencer: (i: number) => T) {
  * If `max` is not an integer, it is rounded down.
  * If `min` >= `max` (after rounding), an empty array is returned.
  */
-export function range(min: number, max: number) {
+export function range(min: number, max: number): Generator<number, void> {
     min = Math.ceil(min);
     max = Math.floor(max);
 
@@ -43,10 +43,30 @@ export function range(min: number, max: number) {
 /**
  * Generate the Cartesian product of a pair of iterables.
  */
-export function* product<A, B>(as: Iterable<A>, bs: Iterable<B>): Generator<[A, B], void, undefined> {
+export function* product<A, B>(as: Iterable<A>, bs: Iterable<B>): Generator<[A, B], void> {
     for (const a of as) {
         for (const b of bs) {
             yield [a, b];
         }
+    }
+}
+
+/**
+ * Pair each element of a sequence with its index starting from `0`.
+ */
+export function* enumerate<T>(iterable: Iterable<T>): Generator<[number, T], void> {
+    let count = 0;
+    for (const item of iterable) {
+        yield [count++, item];
+    }
+}
+
+/**
+ * Call a callback function on each element of an iterable and generate a new iterable with the result.
+ */
+export function* map<T, U>(callbackfn: (value: T, index: number) => U, iterable: Iterable<T>): Generator<U, void> {
+    // TODO delegate when Array.isArray(iterable)
+    for (const item of enumerate(iterable)) {
+        yield callbackfn(item[1], item[0]);
     }
 }

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -65,7 +65,6 @@ export function* enumerate<T>(iterable: Iterable<T>): Generator<[number, T], voi
  * Call a callback function on each element of an iterable and generate a new iterable with the result.
  */
 export function* map<T, U>(callbackfn: (value: T, index: number) => U, iterable: Iterable<T>): Generator<U, void> {
-    // TODO delegate when Array.isArray(iterable)
     for (const item of enumerate(iterable)) {
         yield callbackfn(item[1], item[0]);
     }

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -133,6 +133,25 @@ export function* skip<T>(n: number, iterable: Iterable<T>): Generator<T, void> {
 }
 
 /**
+ * Returns the elements between the indices `start` and `end` of an iterable.
+ * @param {number} start - The zero-based index at which to start the slice (inclusive).
+ * Unlike `Array.prototype.slice`, a negative `start` does not indicate an offset from the end of the iterable.
+ * @param {number} end - The zero-based index at which to end the slice (exclusive).
+ */
+export function slice<T>(iterable: Iterable<T>, start: number, end?: number): Generator<T, void> {
+    if (end === undefined) {
+        return skip(start, iterable);
+    } else {
+        // Do some rounding to match the behavior of `Array.prototype.slice`
+        // when the inputs aren't nonnegative integers.
+        start = Math.max(Math.floor(start), 0);
+        end = Math.floor(end);
+        const sizeOfSlice = end - start;
+        return take(sizeOfSlice, skip(start, iterable));
+    }
+}
+
+/**
  * Produce an iterable of `n` items from a `sequencer` function.
  * @param sequencer - A function that will be passed the index of each element being generated.
  */

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -47,8 +47,11 @@ export function* enumerate<T>(iterable: Iterable<T>): Generator<[number, T], voi
 
 /**
  * Invoke a callback function on each element of an iterable and generate a new iterable with the result.
- * @param callback - A function that is called on each element in the iterable. It may optionally take the current index of the element. The function is called lazily as the result is iterated.
- * @param thisArg - An object which the `this` keyword refers to in `callback`. If `thisArg` is omitted, `this` will be `undefined`.
+ * @param callback - A function that is called on each element in the iterable.
+ * It may optionally take the current index of the element.
+ * The function is called lazily as the result is iterated.
+ * @param thisArg - An object which the `this` keyword refers to in `callback`.
+ * If `thisArg` is omitted, `this` will be `undefined`.
  */
 export function* map<T, U>(iterable: Iterable<T>, callback: (value: T, index: number) => U, thisArg?: any): Generator<U, void> {
     for (const item of enumerate(iterable)) {
@@ -58,20 +61,46 @@ export function* map<T, U>(iterable: Iterable<T>, callback: (value: T, index: nu
 
 /**
  * Return the elements of an iterable for which a callback function is truthy.
- * @param callback - A predicate that is called on each element in the iterable. It may optionally take the current index of the element. The function is called lazily as the result is iterated.
+ * @param predicate - A function that is called on each element in the iterable. It may optionally take the current index of the element.
+ * The function is called lazily as the result is iterated.
  * @param thisArg - An object which the `this` keyword refers to in `callback`. If `thisArg` is omitted, `this` will be `undefined`.
  */
-export function* filter<T>(iterable: Iterable<T>, callback: (value: T, index: number) => unknown, thisArg?: any): Generator<T, void> {
+export function* filter<T>(iterable: Iterable<T>, predicate: (value: T, index: number) => unknown, thisArg?: any): Generator<T, void> {
     for (const item of enumerate(iterable)) {
-        if (callback.call(thisArg, item[1], item[0])) {
+        if (predicate.call(thisArg, item[1], item[0])) {
             yield item[1];
         }
     }
 }
 
 /**
- * Produce an array of `n` items from a `sequencer` function.
- * The `sequencer` function will be passed the index of each element being generated.
+ * Converts an iterable to a single value by using an accumulator function
+ * @param accumulator A function that is called on each element in the iterable along with the previous result of the function.
+ * It may optionally take the current index of the element.
+ * @param initialValue If specified, used as the initial value for `accumulated`.
+ * If not specified, the first element from the iterable will be used as the initial `accumulated` value and the accumulation will start on the second element.
+ * Calling `reduce` on an empty iterable without an initial value will throw a `TypeError`.
+ */
+export function reduce<T>(iterable: Iterable<T>, accumulator: (accumulated: T, current: T, index: number) => T, initialValue?: T): T {
+    if (initialValue === undefined) {
+        // Use the first element as the initial value.
+        const iterator = iterable[Symbol.iterator]();
+        const firstElement = iterator.next();
+        if (firstElement.done) {
+            throw new TypeError('Reduce of empty iterable with no initial value');
+        }
+
+        let accumulated = firstElement.value;
+        // Start the accumulation on the second element.
+        return accumulated;
+    } else {
+        return initialValue;
+    }
+}
+
+/**
+ * Produce an iterable of `n` items from a `sequencer` function.
+ * @param sequencer - A function that will be passed the index of each element being generated.
  */
 export function* sequence<T>(n: number, sequencer: (i: number) => T) {
     for (let i = 0; i < n; i++) {

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -16,16 +16,6 @@ export function* concat<T>(...iterables: Array<Iterable<T>>): Generator<T, void,
 }
 
 /**
- * Produce an array of `n` items from a `sequencer` function.
- * The `sequencer` function will be passed the index of each element being generated.
- */
-export function* sequence<T>(n: number, sequencer: (i: number) => T) {
-    for (let i = 0; i < n; i++) {
-        yield sequencer(i);
-    }
-}
-
-/**
  * Generate a sequence of integers for the half-open set `[min, max)` by increments of `step`.
  * @param {number} min - Lower bound (inclusive) of the range.
  * @param {number} max - Upper bound (exclusive) of the range.
@@ -42,17 +32,6 @@ export function* range(min: number, max: number, step?: number): Generator<numbe
     while (value < max) {
         yield value;
         value += step;
-    }
-}
-
-/**
- * Generate the Cartesian product of a pair of iterables.
- */
-export function* product<A, B>(as: Iterable<A>, bs: Iterable<B>): Generator<[A, B], void> {
-    for (const a of as) {
-        for (const b of bs) {
-            yield [a, b];
-        }
     }
 }
 
@@ -86,6 +65,27 @@ export function* filter<T>(iterable: Iterable<T>, callback: (value: T, index: nu
     for (const item of enumerate(iterable)) {
         if (callback.call(thisArg, item[1], item[0])) {
             yield item[1];
+        }
+    }
+}
+
+/**
+ * Produce an array of `n` items from a `sequencer` function.
+ * The `sequencer` function will be passed the index of each element being generated.
+ */
+export function* sequence<T>(n: number, sequencer: (i: number) => T) {
+    for (let i = 0; i < n; i++) {
+        yield sequencer(i);
+    }
+}
+
+/**
+ * Generate the Cartesian product of a pair of iterables.
+ */
+export function* product<A, B>(as: Iterable<A>, bs: Iterable<B>): Generator<[A, B], void> {
+    for (const a of as) {
+        for (const b of bs) {
+            yield [a, b];
         }
     }
 }

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -67,10 +67,25 @@ export function* enumerate<T>(iterable: Iterable<T>): Generator<[number, T], voi
 }
 
 /**
- * Call a callback function on each element of an iterable and generate a new iterable with the result.
+ * Invoke a callback function on each element of an iterable and generate a new iterable with the result.
+ * @param callback - A function that is called on each element in the iterable. It may optionally take the current index of the element. The function is called lazily as the result is iterated.
+ * @param thisArg - An object which the `this` keyword refers to in `callback`. If `thisArg` is omitted, `this` will be `undefined`.
  */
-export function* map<T, U>(callbackfn: (value: T, index: number) => U, iterable: Iterable<T>): Generator<U, void> {
+export function* map<T, U>(iterable: Iterable<T>, callback: (value: T, index: number) => U, thisArg?: any): Generator<U, void> {
     for (const item of enumerate(iterable)) {
-        yield callbackfn(item[1], item[0]);
+        yield callback.call(thisArg, item[1], item[0]);
+    }
+}
+
+/**
+ * Return the elements of an iterable for which a callback function is truthy.
+ * @param callback - A predicate that is called on each element in the iterable. It may optionally take the current index of the element. The function is called lazily as the result is iterated.
+ * @param thisArg - An object which the `this` keyword refers to in `callback`. If `thisArg` is omitted, `this` will be `undefined`.
+ */
+export function* filter<T>(iterable: Iterable<T>, callback: (value: T, index: number) => unknown, thisArg?: any): Generator<T, void> {
+    for (const item of enumerate(iterable)) {
+        if (callback.call(thisArg, item[1], item[0])) {
+            yield item[1];
+        }
     }
 }

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -39,3 +39,14 @@ export function range(min: number, max: number) {
     const sizeOfRange = Math.max(0, max - min);
     return sequence(sizeOfRange, n => n + min);
 }
+
+/**
+ * Generate the Cartesian product of a pair of iterables.
+ */
+export function* product<A, B>(as: Iterable<A>, bs: Iterable<B>): Generator<[A, B], void, undefined> {
+    for (const a of as) {
+        for (const b of bs) {
+            yield [a, b];
+        }
+    }
+}

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -85,16 +85,24 @@ export function reduce<T>(iterable: Iterable<T>, accumulator: (accumulated: T, c
     if (initialValue === undefined) {
         // Use the first element as the initial value.
         const iterator = iterable[Symbol.iterator]();
-        const firstElement = iterator.next();
-        if (firstElement.done) {
+        let currentElement = iterator.next();
+        if (currentElement.done) {
             throw new TypeError('Reduce of empty iterable with no initial value');
         }
 
-        let accumulated = firstElement.value;
+        let accumulated = currentElement.value;
         // Start the accumulation on the second element.
+        currentElement = iterator.next();
+        for (let i = 1; !currentElement.done; i++, currentElement = iterator.next()) {
+            accumulated = accumulator(accumulated, currentElement.value, i);
+        }
         return accumulated;
     } else {
-        return initialValue;
+        let accumulated = initialValue;
+        for (const item of enumerate(iterable)) {
+            accumulated = accumulator(accumulated, item[1], item[0]);
+        }
+        return accumulated;
     }
 }
 

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -106,6 +106,32 @@ export function reduce<T>(iterable: Iterable<T>, accumulator: (accumulated: T, c
     }
 }
 
+/** Returns the first `n` elements of an iterable. */
+export function* take<T>(n: number, iterable: Iterable<T>): Generator<T, void> {
+    let i = 0;
+    for (const item of iterable) {
+        if (i < n) {
+            yield item;
+            i++;
+        } else {
+            break;
+        }
+    }
+}
+
+/** Returns the elements after the first `n` elements of an iterable. */
+export function* skip<T>(n: number, iterable: Iterable<T>): Generator<T, void> {
+    let i = 0;
+    for (const item of iterable) {
+        if (i >= n) {
+            yield item;
+        } else {
+            // Put this in an `else` so `i` doesn't overflow.
+            i++;
+        }
+    }
+}
+
 /**
  * Produce an iterable of `n` items from a `sequencer` function.
  * @param sequencer - A function that will be passed the index of each element being generated.

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -10,7 +10,7 @@ export function isIterable(obj: any): boolean {
 }
 
 /** Join zero or more iterables into a single iterable. */
-export function* chain<T>(...iterables: Array<Iterable<T>>): Generator<T, void, undefined> {
+export function* concat<T>(...iterables: Array<Iterable<T>>): Generator<T, void, undefined> {
     for (const it of iterables) {
         yield* it;
     }

--- a/src/random.ts
+++ b/src/random.ts
@@ -17,7 +17,7 @@ export function pick<T>(array: Array<T>): T {
 }
 
 /** Create a random permutation of an iterable. */
-export function shuffle<T>(iterable: Iterable<T>) {
+export function shuffle<T>(iterable: Iterable<T>): Generator<T, void> {
     const array = Array.from(iterable);
     return sequence(array.length, () => pick(array));
 }

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -66,6 +66,11 @@ expect.extend({
     }
 });
 
+function pairsStrictEqual(lhs, rhs) {
+    return lhs[0] === rhs[0]
+        && lhs[1] === rhs[1];
+}
+
 // Note that if this fails, the other test results aren't reliable.
 describe('iterable.isIterable', () => {
     function* generatorFunction() {
@@ -131,15 +136,32 @@ describe('iterable.product', () => {
     });
 
     test('returns all permutations of nonempty iterables', () => {
-        function pairsEqual(lhs, rhs) {
-            return lhs[0] === rhs[0]
-                && lhs[1] === rhs[1];
-        }
-
         expect(iterable.product(['a', 'b', 'c'], [1, 2])).toYield([
             ['a', 1], ['a', 2],
             ['b', 1], ['b', 2],
             ['c', 1], ['c', 2]
-        ], pairsEqual);
+        ], pairsStrictEqual);
+    });
+});
+
+describe('iterable.enumerate', () => {
+    test('returns an empty iterable when passed an empty iterable', () => {
+        expect(iterable.enumerate([])).toBeEmptyIterable();
+    });
+
+    test('enumerates a nonempty iterable', () => {
+        expect(iterable.enumerate(['a', 'b', 'c'])).toYield([
+            [0, 'a'], [1, 'b'], [2, 'c']
+        ], pairsStrictEqual);
+    });
+});
+
+describe('iterable.map', () => {
+    test('returns an empty iterable when passed an empty iterable', () => {
+        expect(iterable.map(x => x, [])).toBeEmptyIterable();
+    });
+
+    test('invokes a function on a nonempty iterable', () => {
+        expect(iterable.map(x => 2 * x, [1, 2, 3])).toYield([2, 4, 6]);
     });
 });

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -159,10 +159,21 @@ describe('iterable.enumerate', () => {
 
 describe('iterable.map', () => {
     test('returns an empty iterable when passed an empty iterable', () => {
-        expect(iterable.map(x => x, [])).toBeEmpty();
+        expect(iterable.map([], x => x)).toBeEmpty();
     });
 
     test('invokes a function on a nonempty iterable', () => {
-        expect(iterable.map(x => 2 * x, [1, 2, 3])).toYield([2, 4, 6]);
+        expect(iterable.map([1, 2, 3], x => 2 * x)).toYield([2, 4, 6]);
+    });
+});
+
+describe('iterable.filter', () => {
+    test('returns an empty iterable when passed an empty iterable', () => {
+        expect(iterable.filter([], x => x)).toBeEmpty();
+    });
+
+    test('invokes a predicate on elements from a nonempty iterable', () => {
+        const isEven = x => x % 2 === 0;
+        expect(iterable.filter([0, 1, 2, 3, 4], isEven)).toYield([0, 2, 4]);
     });
 });

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -162,6 +162,38 @@ describe('iterable.filter', () => {
     });
 });
 
+describe('iterable.reduce', () => {
+    test('throws a TypeError when reducing an empty iterable with no initial value', () => {
+        expect(() => iterable.reduce([], x => x)).toThrow(TypeError);
+    });
+
+    test('returns the initial value when called on an empty iterable', () => {
+        expect(iterable.reduce([], x => 2 * x, 1)).toBe(1);
+    });
+
+    test('returns the last element when called with the identity function on a nonempty iterable', () => {
+        expect(iterable.reduce([1, 2, 3], x => x)).toBe(3);
+    });
+
+    // Some accumulator functions
+    const sum = (a, b) => a + b;
+    const and = (a, b) => a && b;
+    const or = (a, b) => a || b;
+
+    test('accumulates the elements in a nonempty iterable', () => {
+        expect(iterable.reduce([0, 1, 2, 3, 4], sum)).toBe(10);
+        expect(iterable.reduce(['hello', ' ', 'world'], sum)).toBe('hello world');
+        expect(iterable.reduce([true, true, true], and)).toBe(true);
+        expect(iterable.reduce([true, true, true], or)).toBe(true);
+        expect(iterable.reduce([true, false, true], and)).toBe(false);
+        expect(iterable.reduce([true, false, true], or)).toBe(true);
+    });
+
+    test('accumulates the elements in a nonempty iterable with an initial value', () => {
+        expect(iterable.reduce([0, 1, 2, 3, 4], sum, 10)).toBe(20);
+    });
+});
+
 describe('iterable.product', () => {
     test('returns an empty iterable when one of the iterables is empty', () => {
         expect(iterable.product([], [])).toBeEmpty();

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -83,17 +83,17 @@ describe('iterable.isIterable', () => {
     });
 });
 
-describe('iterable.chain', () => {
+describe('iterable.concat', () => {
     test('returns an empty iterable when nothing is chained', () => {
-        expect(iterable.chain()).toBeEmpty();
+        expect(iterable.concat()).toBeEmpty();
     });
 
     test('passes through a single argument', () => {
-        expect(iterable.chain([1, 2])).toYield([1, 2]);
+        expect(iterable.concat([1, 2])).toYield([1, 2]);
     });
 
-    test('chains multiple arguments', () => {
-        expect(iterable.chain([1, 2], (function* () { yield 3; yield 4; })(), [5])).toYield([1, 2, 3, 4, 5]);
+    test('joins multiple arguments', () => {
+        expect(iterable.concat([1, 2], (function* () { yield 3; yield 4; })(), [5])).toYield([1, 2, 3, 4, 5]);
     });
 });
 

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -2,19 +2,10 @@
 const iterable = require('../dist/iterable');
 
 expect.extend({
-    toBeEmptyIterable(received) {
-        if (!iterable.isIterable(received)) {
+    toBeEmpty(received) {
+        for (const item in received) {
             return {
-                message: () => `${received} is not iterable`,
-                pass: false
-            };
-        }
-
-        const iterator = received[Symbol.iterator]();
-        const next = iterator.next();
-        if (!next.done) {
-            return {
-                message: () => `${received} is iterable, but it is not empty. First value: ${next.value}`,
+                message: () => `${received} is iterable, but it is not empty. First value: ${item}`,
                 pass: false
             };
         }
@@ -27,13 +18,6 @@ expect.extend({
     toYield(received, expectedValues, elementsEqual) {
         if (elementsEqual === undefined) {
             elementsEqual = (a, b) => a === b;
-        }
-
-        if (!iterable.isIterable(received)) {
-            return {
-                message: () => `${received} is not iterable`,
-                pass: false
-            };
         }
 
         const actual = Array.from(received);
@@ -54,7 +38,7 @@ expect.extend({
         for (let i = 0; i < actual.length; i++) {
             if (!elementsEqual(actual[i], expectedValues[i])) {
                 return {
-                    message: () => `${actual} and ${expectedValues} differ at index ${i} (${actual[i]} !== ${expectedValues[i]})`,
+                    message: () => `${actual} and ${expectedValues} differ at index ${i} (${actual[i]} != ${expectedValues[i]})`,
                     pass: false
                 };
             }
@@ -71,7 +55,6 @@ function pairsStrictEqual(lhs, rhs) {
         && lhs[1] === rhs[1];
 }
 
-// Note that if this fails, the other test results aren't reliable.
 describe('iterable.isIterable', () => {
     function* generatorFunction() {
         yield true;
@@ -102,7 +85,7 @@ describe('iterable.isIterable', () => {
 
 describe('iterable.chain', () => {
     test('returns an empty iterable when nothing is chained', () => {
-        expect(iterable.chain()).toBeEmptyIterable();
+        expect(iterable.chain()).toBeEmpty();
     });
 
     test('passes through a single argument', () => {
@@ -116,8 +99,8 @@ describe('iterable.chain', () => {
 
 describe('iterable.range', () => {
     test('returns an empty iterable for an empty range', () => {
-        expect(iterable.range(1, 0)).toBeEmptyIterable();
-        expect(iterable.range(0, 0)).toBeEmptyIterable();
+        expect(iterable.range(1, 0)).toBeEmpty();
+        expect(iterable.range(0, 0)).toBeEmpty();
     });
 
     test('returns a range of nonzero size', () => {
@@ -130,9 +113,9 @@ describe('iterable.range', () => {
 
 describe('iterable.product', () => {
     test('returns an empty iterable when one of the iterables is empty', () => {
-        expect(iterable.product([], [])).toBeEmptyIterable();
-        expect(iterable.product(['a'], [])).toBeEmptyIterable();
-        expect(iterable.product([], ['a'])).toBeEmptyIterable();
+        expect(iterable.product([], [])).toBeEmpty();
+        expect(iterable.product(['a'], [])).toBeEmpty();
+        expect(iterable.product([], ['a'])).toBeEmpty();
     });
 
     test('returns all permutations of nonempty iterables', () => {
@@ -146,7 +129,7 @@ describe('iterable.product', () => {
 
 describe('iterable.enumerate', () => {
     test('returns an empty iterable when passed an empty iterable', () => {
-        expect(iterable.enumerate([])).toBeEmptyIterable();
+        expect(iterable.enumerate([])).toBeEmpty();
     });
 
     test('enumerates a nonempty iterable', () => {
@@ -158,7 +141,7 @@ describe('iterable.enumerate', () => {
 
 describe('iterable.map', () => {
     test('returns an empty iterable when passed an empty iterable', () => {
-        expect(iterable.map(x => x, [])).toBeEmptyIterable();
+        expect(iterable.map(x => x, [])).toBeEmpty();
     });
 
     test('invokes a function on a nonempty iterable', () => {

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -225,6 +225,43 @@ describe('iterable.skip', () => {
     });
 });
 
+describe('iterable.slice', () => {
+    test('returns an empty iterable when the input iterable is empty', () => {
+        expect(iterable.slice([], 2, 5)).toBeEmpty();
+    });
+
+    test('returns the last elements of an iterable when only `start` is given', () => {
+        expect(iterable.slice([1, 2, 3, 4], 2)).toYield([3, 4]);
+    });
+
+    test('returns the elements between `start` and `end`', () => {
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], 2, 3)).toYield([3]);
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], 2, 4)).toYield([3, 4]);
+    });
+
+    test('works when `start` or `end` are at the boundaries of the iterable', () => {
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], 0, 3)).toYield([1, 2, 3]);
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], 2, 5)).toYield([3, 4, 5]);
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], 0, 5)).toYield([1, 2, 3, 4, 5]);
+    });
+
+    test('works when `start` or `end` are outside the boundaries of the iterable', () => {
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], -1, 3)).toYield([1, 2, 3]);
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], 2, 6)).toYield([3, 4, 5, 6]);
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], 0, 6)).toYield([1, 2, 3, 4, 5, 6]);
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], -1, 7)).toYield([1, 2, 3, 4, 5, 6]);
+    });
+
+    test('works with floating-point bounds', () => {
+        expect(iterable.slice([1, 2, 3, 4, 5, 6], 0.2, 3.8)).toYield([1, 2, 3]);
+    });
+
+    test('returns an empty iterable when `start <= end`', () => {
+        expect(iterable.slice([1, 2, 3, 4], 2, 1)).toBeEmpty();
+        expect(iterable.slice([1, 2, 3, 4], 2, 2)).toBeEmpty();
+    });
+});
+
 describe('iterable.product', () => {
     test('returns an empty iterable when one of the iterables is empty', () => {
         expect(iterable.product([], [])).toBeEmpty();

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -194,6 +194,37 @@ describe('iterable.reduce', () => {
     });
 });
 
+describe('iterable.take', () => {
+    test('returns an empty iterable when the input iterable is empty', () => {
+        expect(iterable.take(5, [])).toBeEmpty();
+    });
+
+    test('returns the first elements of an iterable', () => {
+        expect(iterable.take(2, [1, 2, 3, 4])).toYield([1, 2]);
+    });
+
+    test('returns an empty iterable when `n < 1`', () => {
+        expect(iterable.take(-1, [1, 2, 3, 4])).toBeEmpty();
+        expect(iterable.take(0, [1, 2, 3, 4])).toBeEmpty();
+        expect(iterable.take(0.8, [1, 2, 3, 4])).toBeEmpty();
+    });
+});
+
+describe('iterable.skip', () => {
+    test('returns an empty iterable when the input iterable is empty', () => {
+        expect(iterable.skip(5, [])).toBeEmpty();
+    });
+
+    test('returns the last elements of an iterable', () => {
+        expect(iterable.skip(2, [1, 2, 3, 4])).toYield([3, 4]);
+    });
+
+    test('returns the whole iterable when `n <= 0`', () => {
+        expect(iterable.skip(-1, [1, 2, 3, 4])).toYield([1, 2, 3, 4]);
+        expect(iterable.skip(0, [1, 2, 3, 4])).toYield([1, 2, 3, 4]);
+    });
+});
+
 describe('iterable.product', () => {
     test('returns an empty iterable when one of the iterables is empty', () => {
         expect(iterable.product([], [])).toBeEmpty();

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -129,22 +129,6 @@ describe('iterable.range', () => {
     });
 });
 
-describe('iterable.product', () => {
-    test('returns an empty iterable when one of the iterables is empty', () => {
-        expect(iterable.product([], [])).toBeEmpty();
-        expect(iterable.product(['a'], [])).toBeEmpty();
-        expect(iterable.product([], ['a'])).toBeEmpty();
-    });
-
-    test('returns all permutations of nonempty iterables', () => {
-        expect(iterable.product(['a', 'b', 'c'], [1, 2])).toYield([
-            ['a', 1], ['a', 2],
-            ['b', 1], ['b', 2],
-            ['c', 1], ['c', 2]
-        ], pairsStrictEqual);
-    });
-});
-
 describe('iterable.enumerate', () => {
     test('returns an empty iterable when passed an empty iterable', () => {
         expect(iterable.enumerate([])).toBeEmpty();
@@ -175,5 +159,21 @@ describe('iterable.filter', () => {
     test('invokes a predicate on elements from a nonempty iterable', () => {
         const isEven = x => x % 2 === 0;
         expect(iterable.filter([0, 1, 2, 3, 4], isEven)).toYield([0, 2, 4]);
+    });
+});
+
+describe('iterable.product', () => {
+    test('returns an empty iterable when one of the iterables is empty', () => {
+        expect(iterable.product([], [])).toBeEmpty();
+        expect(iterable.product(['a'], [])).toBeEmpty();
+        expect(iterable.product([], ['a'])).toBeEmpty();
+    });
+
+    test('returns all permutations of nonempty iterables', () => {
+        expect(iterable.product(['a', 'b', 'c'], [1, 2])).toYield([
+            ['a', 1], ['a', 2],
+            ['b', 1], ['b', 2],
+            ['c', 1], ['c', 2]
+        ], pairsStrictEqual);
     });
 });

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -101,13 +101,31 @@ describe('iterable.range', () => {
     test('returns an empty iterable for an empty range', () => {
         expect(iterable.range(1, 0)).toBeEmpty();
         expect(iterable.range(0, 0)).toBeEmpty();
+        expect(iterable.range(0, 0, 4)).toBeEmpty();
     });
 
-    test('returns a range of nonzero size', () => {
+    test('returns a range for integer bounds', () => {
         expect(iterable.range(0, 1)).toYield([0]);
         expect(iterable.range(0, 5)).toYield([0, 1, 2, 3, 4]);
         expect(iterable.range(3, 6)).toYield([3, 4, 5]);
         expect(iterable.range(-2, 0)).toYield([-2, -1]);
+    });
+
+    test('returns a range with a step size for integer bounds', () => {
+        expect(iterable.range(0, 1, 3)).toYield([0]);
+        expect(iterable.range(0, 5, 1)).toYield([0, 1, 2, 3, 4]);
+        expect(iterable.range(3, 6, 2)).toYield([3, 5]);
+    });
+
+    test('rejects a nonpositive step size', () => {
+        expect(() => [...iterable.range(0, 1, -1)]).toThrow(RangeError);
+        expect(() => [...iterable.range(0, 5, 0)]).toThrow(RangeError);
+    });
+
+    test('returns a range for floating-point bounds', () => {
+        // Checking equality with floats is bad, but using literals and adding integers should be predictable.
+        // If this becomes flaky, pass an approximate equality function to `toYield`.
+        expect(iterable.range(0.5, 3.6)).toYield([0.5, 1.5, 2.5, 3.5]);
     });
 });
 

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -24,7 +24,11 @@ expect.extend({
         };
     },
 
-    toYield(received, ...expectedValues) {
+    toYield(received, expectedValues, elementsEqual) {
+        if (elementsEqual === undefined) {
+            elementsEqual = (a, b) => a === b;
+        }
+
         if (!iterable.isIterable(received)) {
             return {
                 message: () => `${received} is not iterable`,
@@ -48,7 +52,7 @@ expect.extend({
 
         // `actual` and `expectedValues` have the same length
         for (let i = 0; i < actual.length; i++) {
-            if (actual[i] !== expectedValues[i]) {
+            if (!elementsEqual(actual[i], expectedValues[i])) {
                 return {
                     message: () => `${actual} and ${expectedValues} differ at index ${i} (${actual[i]} !== ${expectedValues[i]})`,
                     pass: false
@@ -97,11 +101,11 @@ describe('iterable.chain', () => {
     });
 
     test('passes through a single argument', () => {
-        expect(iterable.chain([1, 2])).toYield(1, 2);
+        expect(iterable.chain([1, 2])).toYield([1, 2]);
     });
 
     test('chains multiple arguments', () => {
-        expect(iterable.chain([1, 2], (function* () { yield 3; yield 4; })(), [5])).toYield(1, 2, 3, 4, 5);
+        expect(iterable.chain([1, 2], (function* () { yield 3; yield 4; })(), [5])).toYield([1, 2, 3, 4, 5]);
     });
 });
 
@@ -112,9 +116,30 @@ describe('iterable.range', () => {
     });
 
     test('returns a range of nonzero size', () => {
-        expect(iterable.range(0, 1)).toYield(0);
-        expect(iterable.range(0, 5)).toYield(0, 1, 2, 3, 4);
-        expect(iterable.range(3, 6)).toYield(3, 4, 5);
-        expect(iterable.range(-2, 0)).toYield(-2, -1);
+        expect(iterable.range(0, 1)).toYield([0]);
+        expect(iterable.range(0, 5)).toYield([0, 1, 2, 3, 4]);
+        expect(iterable.range(3, 6)).toYield([3, 4, 5]);
+        expect(iterable.range(-2, 0)).toYield([-2, -1]);
+    });
+});
+
+describe('iterable.product', () => {
+    test('returns an empty iterable when one of the iterables is empty', () => {
+        expect(iterable.product([], [])).toBeEmptyIterable();
+        expect(iterable.product(['a'], [])).toBeEmptyIterable();
+        expect(iterable.product([], ['a'])).toBeEmptyIterable();
+    });
+
+    test('returns all permutations of nonempty iterables', () => {
+        function pairsEqual(lhs, rhs) {
+            return lhs[0] === rhs[0]
+                && lhs[1] === rhs[1];
+        }
+
+        expect(iterable.product(['a', 'b', 'c'], [1, 2])).toYield([
+            ['a', 1], ['a', 2],
+            ['b', 1], ['b', 2],
+            ['c', 1], ['c', 2]
+        ], pairsEqual);
     });
 });

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -171,8 +171,8 @@ describe('iterable.reduce', () => {
         expect(iterable.reduce([], x => 2 * x, 1)).toBe(1);
     });
 
-    test('returns the last element when called with the identity function on a nonempty iterable', () => {
-        expect(iterable.reduce([1, 2, 3], x => x)).toBe(3);
+    test('returns the first element when called with the identity function on a nonempty iterable', () => {
+        expect(iterable.reduce([1, 2, 3], x => x)).toBe(1);
     });
 
     // Some accumulator functions


### PR DESCRIPTION
## Changes

This adds almost all of the `Array` methods for iterables.

### New functions
- `enumerate`
- `map`
- `filter`
- `reduce`
- `take`
- `skip`
- `slice`
- `product`

### Changed functions
- Rename `chain` to `concat` to match `Array` (and LINQ)
- Have `range` take a step size

### TODO
- `flat` and `flatMap` aren't yet implemented.