### PR TITLE
Put function parameters first

### DIFF
--- a/docs/example/with.js
+++ b/docs/example/with.js
@@ -6,11 +6,11 @@ const random = require('../../dist/random');
 
 // Create the deck.
 const deck = iterable.map(
+    pair => { return { suit: pair[0], rank: pair[1] } },
     iterable.product(
         ['Hearts', 'Diamonds', 'Clubs', 'Spades'],
         iterable.concat(iterable.range(2, 11), ['J', 'Q', 'K', 'A'])
-    ),
-    pair => { return { suit: pair[0], rank: pair[1] } }
+    )
 );
 
 // Shuffle the deck.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-helpers",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-helpers",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-helpers",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Zero-dependency library that makes coding in JavaScript a little nicer.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -65,9 +65,9 @@ export function* enumerate<T>(iterable: Iterable<T>): Generator<[number, T], voi
  * @param thisArg - An object which the `this` keyword refers to in `callback`.
  * If `thisArg` is omitted, `this` will be `undefined`.
  */
-export function* map<T, U>(iterable: Iterable<T>, callback: (value: T, index: number) => U, thisArg?: any): Generator<U, void> {
-    for (const [index, item] of enumerate(iterable)) {
-        yield callback.call(thisArg, item, index);
+ export function* map<T, U>(callback: (value: T, index: number) => U, iterable: Iterable<T>, thisArg?: any): Generator<U, void> {
+    for (const item of enumerate(iterable)) {
+        yield callback.call(thisArg, item[1], item[0]);
     }
 }
 
@@ -77,10 +77,10 @@ export function* map<T, U>(iterable: Iterable<T>, callback: (value: T, index: nu
  * The function is called lazily as the result is iterated.
  * @param thisArg - An object which the `this` keyword refers to in `callback`. If `thisArg` is omitted, `this` will be `undefined`.
  */
-export function* filter<T>(iterable: Iterable<T>, predicate: (value: T, index: number) => unknown, thisArg?: any): Generator<T, void> {
-    for (const [index, item] of enumerate(iterable)) {
-        if (predicate.call(thisArg, item, index)) {
-            yield item;
+export function* filter<T>(predicate: (value: T, index: number) => unknown, iterable: Iterable<T>, thisArg?: any): Generator<T, void> {
+    for (const item of enumerate(iterable)) {
+        if (predicate.call(thisArg, item[1], item[0])) {
+            yield item[1];
         }
     }
 }
@@ -93,7 +93,7 @@ export function* filter<T>(iterable: Iterable<T>, predicate: (value: T, index: n
  * If not specified, the first element from the iterable will be used as the initial `accumulated` value and the accumulation will start on the second element.
  * Calling `reduce` on an empty iterable without an initial value will throw a `TypeError`.
  */
-export function reduce<T>(iterable: Iterable<T>, accumulator: (accumulated: T, current: T, index: number) => T, initialValue?: T): T {
+export function reduce<T>(accumulator: (accumulated: T, current: T, index: number) => T, iterable: Iterable<T>, initialValue?: T): T {
     if (initialValue === undefined) {
         // Use the first element as the initial value.
         const iterator = iterable[Symbol.iterator]();
@@ -214,8 +214,8 @@ export function* flat(iterable: Iterable<any>, depth?: number): Generator<any, v
  * If `thisArg` is omitted, `this` will be `undefined`.
  */
 export function* flatMap<T, U>(
-    iterable: Iterable<T>,
     callback: (value: T, index: number) => U | Iterable<U>,
+    iterable: Iterable<T>,
     thisArg?: any): Generator<U, void, undefined> {
     for (const [index, item] of enumerate(iterable)) {
         const result = callback.call(thisArg, item, index);

--- a/test/iterable.test.js
+++ b/test/iterable.test.js
@@ -153,36 +153,36 @@ describe('iterable.enumerate', () => {
 
 describe('iterable.map', () => {
     test('returns an empty iterable when passed an empty iterable', () => {
-        expect(iterable.map([], x => x)).toBeEmpty();
+        expect(iterable.map(x => x, [])).toBeEmpty();
     });
 
     test('invokes a function on a nonempty iterable', () => {
-        expect(iterable.map([1, 2, 3], x => 2 * x)).toYield([2, 4, 6]);
+        expect(iterable.map( x => 2 * x, [1, 2, 3])).toYield([2, 4, 6]);
     });
 });
 
 describe('iterable.filter', () => {
     test('returns an empty iterable when passed an empty iterable', () => {
-        expect(iterable.filter([], x => x)).toBeEmpty();
+        expect(iterable.filter(x => x, [])).toBeEmpty();
     });
 
     test('invokes a predicate on elements from a nonempty iterable', () => {
         const isEven = x => x % 2 === 0;
-        expect(iterable.filter([0, 1, 2, 3, 4], isEven)).toYield([0, 2, 4]);
+        expect(iterable.filter(isEven, [0, 1, 2, 3, 4])).toYield([0, 2, 4]);
     });
 });
 
 describe('iterable.reduce', () => {
     test('throws a TypeError when reducing an empty iterable with no initial value', () => {
-        expect(() => iterable.reduce([], x => x)).toThrow(TypeError);
+        expect(() => iterable.reduce(x => x, [])).toThrow(TypeError);
     });
 
     test('returns the initial value when called on an empty iterable', () => {
-        expect(iterable.reduce([], x => 2 * x, 1)).toBe(1);
+        expect(iterable.reduce(x => 2 * x, [], 1)).toBe(1);
     });
 
     test('returns the first element when called with the identity function on a nonempty iterable', () => {
-        expect(iterable.reduce([1, 2, 3], x => x)).toBe(1);
+        expect(iterable.reduce(x => x, [1, 2, 3])).toBe(1);
     });
 
     // Some accumulator functions
@@ -191,16 +191,16 @@ describe('iterable.reduce', () => {
     const or = (a, b) => a || b;
 
     test('accumulates the elements in a nonempty iterable', () => {
-        expect(iterable.reduce([0, 1, 2, 3, 4], sum)).toBe(10);
-        expect(iterable.reduce(['hello', ' ', 'world'], sum)).toBe('hello world');
-        expect(iterable.reduce([true, true, true], and)).toBe(true);
-        expect(iterable.reduce([true, true, true], or)).toBe(true);
-        expect(iterable.reduce([true, false, true], and)).toBe(false);
-        expect(iterable.reduce([true, false, true], or)).toBe(true);
+        expect(iterable.reduce(sum, [0, 1, 2, 3, 4])).toBe(10);
+        expect(iterable.reduce(sum, ['hello', ' ', 'world'])).toBe('hello world');
+        expect(iterable.reduce(and, [true, true, true])).toBe(true);
+        expect(iterable.reduce(or, [true, true, true])).toBe(true);
+        expect(iterable.reduce(and, [true, false, true])).toBe(false);
+        expect(iterable.reduce(or, [true, false, true])).toBe(true);
     });
 
     test('accumulates the elements in a nonempty iterable with an initial value', () => {
-        expect(iterable.reduce([0, 1, 2, 3, 4], sum, 10)).toBe(20);
+        expect(iterable.reduce(sum, [0, 1, 2, 3, 4], 10)).toBe(20);
     });
 });
 
@@ -360,20 +360,20 @@ describe('iterable.flat', () => {
 
 describe('iterable.flatMap', () => {
     test('returns an empty iterable when passed an empty iterable', () => {
-        expect(iterable.flatMap([], x => x)).toBeEmpty();
+        expect(iterable.flatMap(x => x, [])).toBeEmpty();
     });
 
     test('invokes a function on a nonempty iterable', () => {
         // Need to use `Array.from` + `toEqual` here.
         // `toYield` can't handle deep equality.
-        expect(Array.from(iterable.flatMap([1, 2, 3], x => [...new Array(x).keys()])))
+        expect(Array.from(iterable.flatMap(x => [...new Array(x).keys()], [1, 2, 3])))
             .toEqual([ 0, 0, 1, 0, 1, 2 ]);
     });
 
     test('is equivalent to `flat` when mapping the identity function', () => {
-        expect(Array.from(iterable.flatMap([1, [2, 3, 4]], x => x))).toEqual([1, 2, 3, 4]);
-        expect(Array.from(iterable.flatMap([1, [2, [3, 4]]], x => x))).toEqual([1, 2, [3, 4]]);
-        expect(Array.from(iterable.flatMap([1, [2, [3, [4]]]], x => x))).toEqual([1, 2, [3, [4]]]);
+        expect(Array.from(iterable.flatMap(x => x, [1, [2, 3, 4]]))).toEqual([1, 2, 3, 4]);
+        expect(Array.from(iterable.flatMap(x => x, [1, [2, [3, 4]]]))).toEqual([1, 2, [3, 4]]);
+        expect(Array.from(iterable.flatMap(x => x, [1, [2, [3, [4]]]]))).toEqual([1, 2, [3, [4]]]);
     });
 });
 


### PR DESCRIPTION
`map`, `flatMap`, `filter`, and `reduce` now all take a function as their first argument and the iterable as their second argument.